### PR TITLE
Revert "chore: cleanup dotnet-sdk stuff, update to python3.8"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # See https://hub.docker.com/r/library/python/
-FROM python:3.7.2-slim-stretch
+FROM python:3.8-slim-buster
 
 LABEL Name=pautomate Version=0.0.1
 
@@ -17,11 +17,10 @@ RUN apt-get install -y apt-transport-https
 RUN apt-get update
 RUN apt-get install -y dotnet-sdk-2.2
 
-WORKDIR /.package
-ADD . /.package
+WORKDIR /package
+COPY . /package
 
-# Using pip:
-RUN python3.7 -m pip install -e .
+RUN python3 -m pip install -e .
 
 WORKDIR /ws
 ENTRYPOINT [ "pautomate" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,27 @@
 # See https://hub.docker.com/r/library/python/
-FROM python:3.8-slim-buster
+FROM python:3.7.2-slim-stretch
 
 LABEL Name=pautomate Version=0.0.1
 
-WORKDIR /package
-ADD . /package
-RUN python3 -m pip install -e .
+
+RUN apt-get update && apt-get install -y git wget gpg
+
+RUN wget -qO- https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > microsoft.asc.gpg
+RUN mv microsoft.asc.gpg /etc/apt/trusted.gpg.d/
+RUN wget -q https://packages.microsoft.com/config/debian/9/prod.list
+RUN mv prod.list /etc/apt/sources.list.d/microsoft-prod.list
+RUN chown root:root /etc/apt/trusted.gpg.d/microsoft.asc.gpg
+RUN chown root:root /etc/apt/sources.list.d/microsoft-prod.list
+
+RUN apt-get install -y apt-transport-https
+RUN apt-get update
+RUN apt-get install -y dotnet-sdk-2.2
+
+WORKDIR /.package
+ADD . /.package
+
+# Using pip:
+RUN python3.7 -m pip install -e .
 
 WORKDIR /ws
 ENTRYPOINT [ "pautomate" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,12 @@ FROM python:3.8-slim-buster
 LABEL Name=pautomate Version=0.0.1
 
 
-RUN apt-get update && apt-get install -y git wget gpg
+RUN apt-get update && apt-get install -y --no-install-recommends \
+	git=1:2.20.1-2 \
+	wget=1.20.1-1.1 \
+	gpg=2.2.12-1+deb10u1 \
+	&& apt-get clean \
+	&& rm -rf /var/lib/apt/lists/*
 
 RUN wget -qO- https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > microsoft.asc.gpg
 RUN mv microsoft.asc.gpg /etc/apt/trusted.gpg.d/
@@ -13,9 +18,12 @@ RUN mv prod.list /etc/apt/sources.list.d/microsoft-prod.list
 RUN chown root:root /etc/apt/trusted.gpg.d/microsoft.asc.gpg
 RUN chown root:root /etc/apt/sources.list.d/microsoft-prod.list
 
-RUN apt-get install -y apt-transport-https
-RUN apt-get update
-RUN apt-get install -y dotnet-sdk-2.2
+RUN apt-get update && apt-get install -y --no-install-recommends \
+	apt-transport-https=1.8.2 \
+	dotnet-sdk-3.0=3.0.100-1 \
+	&& apt-get clean \
+	&& rm -rf /var/lib/apt/lists/*
+
 
 WORKDIR /package
 COPY . /package


### PR DESCRIPTION
Reverts ammarnajjar/pautomate#10
donet-sdk is needed to automate dotnet stuff.. eack!
let's update that also to dotnet-sdk-3.0 😉 